### PR TITLE
fix/dbt_artifacts_tests

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,5 +11,3 @@ models:
       +materialized: incremental
     staging:
       +materialized: view # The staging tables cannot be ephemeral
-
-profile: mack_weldon_snowflake

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,3 +11,5 @@ models:
       +materialized: incremental
     staging:
       +materialized: view # The staging tables cannot be ephemeral
+
+profile: mack_weldon_snowflake

--- a/models/fct_dbt_latest_full_model_executions.sql
+++ b/models/fct_dbt_latest_full_model_executions.sql
@@ -22,7 +22,8 @@ latest_full as (
 
 joined as (
 
-    select
+    select 
+        {{ dbt_utils.surrogate_key(['model_executions.command_invocation_id', 'model_executions.node_id', 'model_executions.model_schema']) }} as latest_model_id,
         model_executions.*
     from latest_full
     left join model_executions 

--- a/models/incremental/fct_dbt_model_executions.sql
+++ b/models/incremental/fct_dbt_model_executions.sql
@@ -35,6 +35,7 @@ model_executions_incremental as (
 model_executions_with_materialization as (
 
     select
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'models.node_id', 'models.model_schema']) }} as model_id,
         model_executions_incremental.*,
         models.model_materialization,
         models.model_schema,

--- a/models/incremental/fct_dbt_test_executions.sql
+++ b/models/incremental/fct_dbt_test_executions.sql
@@ -4,7 +4,14 @@
 
 with tests as (
 
-    select * from {{ ref('int_dbt_tests') }}
+    select distinct
+        node_id,
+        test_name,
+        test_type,
+        model_schema,
+        depends_on_nodes,
+        model_path
+     from {{ ref('int_dbt_tests') }}
 
 ),
 
@@ -27,10 +34,15 @@ test_executions_incremental as (
 
 test_executions_with_materialization as (
 
-    select
+    select 
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'tests.node_id', 'tests.model_schema']) }} as test_id,
         test_executions_incremental.*,
         tests.test_name,
-        tests.test_type
+        tests.test_type,
+        tests.model_schema,
+        tests.depends_on_nodes,
+        tests.model_path
+
     from test_executions_incremental
     left join tests 
         on test_executions_incremental.node_id = tests.node_id

--- a/models/schemas.yml
+++ b/models/schemas.yml
@@ -8,7 +8,7 @@ models:
       description: Primary key.
       tests:
         - unique
-          severity: warn
+          severity:warn
         - not_null
     - name: index
       description: The index of the model in the critical path. Starts at 0.
@@ -19,11 +19,11 @@ models:
   - name: fct_dbt_latest_full_model_executions
     description: A list of all models and executions times from the most recent, incremental run.
     columns:
-    - name: node_id
+    - name: latest_model_id
       description: Primary key.
       tests:
         - unique
-          severity: warn
+          severity:warn
         - not_null
     - name: artifact_generated_at
       description: Timestamp of when the source artifact was generated.
@@ -51,11 +51,11 @@ models:
   - name: fct_dbt_model_executions
     description: All historic dbt model executions.
     columns:
-    - name: model_execution_id
+    - name: model_id
       description: Primary key.
       tests:
         - unique
-          severity: warn
+          severity:warn
         - not_null
     - name: name
       description: The name of the model.
@@ -85,11 +85,11 @@ models:
   - name: fct_dbt_test_executions
     description: All historic dbt test executions.
     columns:
-    - name: test_execution_id
+    - name: test_id
       description: Primary key.
       tests:
         - unique
-          severity: warn
+          severity:warn
         - not_null
     - name: name
       description: The name of the model.
@@ -117,7 +117,7 @@ models:
       description: Primary key.
       tests:
         - unique
-          severity: warn
+          severity:warn
         - not_null
     - name: name
       description: The name of the model.
@@ -153,7 +153,7 @@ models:
       description: The id of the command which resulted in the source artifact's generation.
       tests:
         - unique
-          severity: warn
+          severity:warn
         - not_null
     - name: artifact_generated_at
       description: Timestamp of when the source artifact was generated.
@@ -193,7 +193,7 @@ models:
         description: Primary key generated from the command_invocation_id and checksum.
         tests:
           - unique
-            severity: warn
+            severity:warn
           - not_null
       - name: command_invocation_id
         description: The id of the command which resulted in the source artifact's generation.
@@ -220,7 +220,7 @@ models:
         description: Primary key generated from the command_invocation_id and checksum.
         tests:
           - unique
-            severity: warn
+            severity:warn
           - not_null
       - name: command_invocation_id
         description: The id of the command which resulted in the source artifact's generation.

--- a/models/schemas.yml
+++ b/models/schemas.yml
@@ -8,6 +8,7 @@ models:
       description: Primary key.
       tests:
         - unique
+          severity: warn
         - not_null
     - name: index
       description: The index of the model in the critical path. Starts at 0.
@@ -22,6 +23,7 @@ models:
       description: Primary key.
       tests:
         - unique
+          severity: warn
         - not_null
     - name: artifact_generated_at
       description: Timestamp of when the source artifact was generated.
@@ -53,6 +55,7 @@ models:
       description: Primary key.
       tests:
         - unique
+          severity: warn
         - not_null
     - name: name
       description: The name of the model.
@@ -187,6 +190,7 @@ models:
         description: Primary key generated from the command_invocation_id and checksum.
         tests:
           - unique
+            severity: warn
           - not_null
       - name: command_invocation_id
         description: The id of the command which resulted in the source artifact's generation.
@@ -213,6 +217,7 @@ models:
         description: Primary key generated from the command_invocation_id and checksum.
         tests:
           - unique
+            severity: warn
           - not_null
       - name: command_invocation_id
         description: The id of the command which resulted in the source artifact's generation.

--- a/models/schemas.yml
+++ b/models/schemas.yml
@@ -8,7 +8,6 @@ models:
       description: Primary key.
       tests:
         - unique
-          severity:warn
         - not_null
     - name: index
       description: The index of the model in the critical path. Starts at 0.
@@ -23,7 +22,6 @@ models:
       description: Primary key.
       tests:
         - unique
-          severity:warn
         - not_null
     - name: artifact_generated_at
       description: Timestamp of when the source artifact was generated.
@@ -55,7 +53,6 @@ models:
       description: Primary key.
       tests:
         - unique
-          severity:warn
         - not_null
     - name: name
       description: The name of the model.
@@ -89,7 +86,6 @@ models:
       description: Primary key.
       tests:
         - unique
-          severity:warn
         - not_null
     - name: name
       description: The name of the model.
@@ -117,7 +113,6 @@ models:
       description: Primary key.
       tests:
         - unique
-          severity:warn
         - not_null
     - name: name
       description: The name of the model.
@@ -153,7 +148,6 @@ models:
       description: The id of the command which resulted in the source artifact's generation.
       tests:
         - unique
-          severity:warn
         - not_null
     - name: artifact_generated_at
       description: Timestamp of when the source artifact was generated.
@@ -193,7 +187,6 @@ models:
         description: Primary key generated from the command_invocation_id and checksum.
         tests:
           - unique
-            severity:warn
           - not_null
       - name: command_invocation_id
         description: The id of the command which resulted in the source artifact's generation.
@@ -220,7 +213,6 @@ models:
         description: Primary key generated from the command_invocation_id and checksum.
         tests:
           - unique
-            severity:warn
           - not_null
       - name: command_invocation_id
         description: The id of the command which resulted in the source artifact's generation.

--- a/models/schemas.yml
+++ b/models/schemas.yml
@@ -89,6 +89,7 @@ models:
       description: Primary key.
       tests:
         - unique
+          severity: warn
         - not_null
     - name: name
       description: The name of the model.
@@ -116,6 +117,7 @@ models:
       description: Primary key.
       tests:
         - unique
+          severity: warn
         - not_null
     - name: name
       description: The name of the model.
@@ -151,6 +153,7 @@ models:
       description: The id of the command which resulted in the source artifact's generation.
       tests:
         - unique
+          severity: warn
         - not_null
     - name: artifact_generated_at
       description: Timestamp of when the source artifact was generated.

--- a/models/staging/stg_dbt_models.sql
+++ b/models/staging/stg_dbt_models.sql
@@ -34,7 +34,7 @@ flatten as (
 surrogate_key as (
 
     select
-        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_model_id,
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id', 'model_schema']) }} as manifest_model_id,
         flatten.*
     from flatten
 

--- a/models/staging/stg_dbt_tests.sql
+++ b/models/staging/stg_dbt_tests.sql
@@ -34,7 +34,7 @@ flatten as (
 surrogate_key as (
 
     select
-        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_test_id,
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id', 'model_schema']) }} as manifest_test_id,
         *
     from flatten
 


### PR DESCRIPTION
#### Updating dbt_artifacts Tests ####

The `dbt_artifacts` package currently has unique tests on  `fct_dbt_critical_path`, `fct_dbt_latest_full_model_executions`, `fct_dbt_model_executions`, `fct_dbt_test_executions`, `fct_dbt_source_freshness`, `fct_dbt_run_results`, `int_dbt_models` and `int_dbt_sources`.

After the `dbt_artifacts` package was added into dbt, there have been errors on unique tests for: 
- `fct_dbt_latest_full_model_executions` 
- `fct_dbt_model_executions` 
- `fct_dbt_test_executions`

This PR adds an additional unique_id field to `fct_dbt_latest_model_executions`, `fct_dbt_model_executions`, and `fct_dbt_test_executions` that include the use of the model_schema field. The model_schema field is added during a join within these fct models. The new unique fields are: `latest_model_id`, `model_id`, and `test_id`. 

#### Error Message ####
![image](https://user-images.githubusercontent.com/51203041/115298957-29643c80-a12c-11eb-8073-419be28f74a0.png)

#### Model Validation ####
**Models**
![image](https://user-images.githubusercontent.com/51203041/115442970-a650ee00-a1e0-11eb-99b5-91d6a1b71aba.png)

**Tests** 
![image](https://user-images.githubusercontent.com/51203041/115442946-9b965900-a1e0-11eb-8469-b8b947b08534.png)
