### PR TITLE
fix/dbt_artifact model test update

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,5 +11,3 @@ models:
       +materialized: incremental
     staging:
       +materialized: view # The staging tables cannot be ephemeral
-
-profile: mack_weldon_snowflake

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -11,3 +11,5 @@ models:
       +materialized: incremental
     staging:
       +materialized: view # The staging tables cannot be ephemeral
+
+profile: mack_weldon_snowflake

--- a/models/schemas.yml
+++ b/models/schemas.yml
@@ -21,7 +21,8 @@ models:
     - name: latest_model_id
       description: Primary key.
       tests:
-        - unique
+        - unique:
+            severity: warn
         - not_null
     - name: artifact_generated_at
       description: Timestamp of when the source artifact was generated.
@@ -52,7 +53,8 @@ models:
     - name: model_id
       description: Primary key.
       tests:
-        - unique
+        - unique:
+            severity: warn
         - not_null
     - name: name
       description: The name of the model.


### PR DESCRIPTION
### dbt_artifact Model Tests ###

This PR adds an additional field to the unique key to the unique test for `model_id` in `fct_dbt_model_executions` and `fct_dbt_latest_full_model_executions`.  It appears that the issue is stemming from `stg_shopify_shipping_lines` materializing as both table and incremental. 

#### Example Duplicate model_id ####
![image](https://user-images.githubusercontent.com/51203041/117362812-b972e780-ae89-11eb-9d34-81a2cfd3436b.png)


#### Before: Error ####
![image](https://user-images.githubusercontent.com/51203041/117350232-53329880-ae7a-11eb-890b-0c16b2ae1ba4.png)

#### After: Warn  ####
![image](https://user-images.githubusercontent.com/51203041/117349671-aa843900-ae79-11eb-996c-1649a8fd9fa7.png)
