### PR TITLE
fix/dbt artifacts pkg update

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
-    version: 0.6.4
+  - package: dbt-labs/dbt_utils
+    version: [">=0.7.0", "<0.8.0"]


### PR DESCRIPTION
## Description: ##

dbt recently upgraded to 0.20.1, and there were package updates made for dbt_utils. Because of Fishtown Analytics recent name change to dbt Labs, there were issues updating packages in our dbt project because of dependency conflicts. the `dbt_artifacts` package was still referencing `fishtown-analytics/dbt_utils` while `dbt_utils` and the rest of the packages in our dbt project are now referencing `dbt-labs/dbt_utils`. Because of this, dbt is unable to determine that these are actually the same package, and instead thinks that the user is trying to update two packages with the same name. Updating the `dbt_artifacts` package to `dbt-labs/dbt_utils` will allow for our dbt project to correctly update all dbt packages. 

## Screenshots & Links ##

###  Dependency Error
![image](https://user-images.githubusercontent.com/51203041/129607028-83e13355-929c-4ea0-99a3-ef5f8f9a244f.png)

[dbt Package Update Discourse](https://discourse.getdbt.com/t/packages-dbt-labs-in-the-dbt-hub/2711)

### After 0.20.1 dbt Update and 0.7.1 `dbt_utils` Update

#### `dbt_artifacts` - Run
![image](https://user-images.githubusercontent.com/51203041/129607903-c947a9c4-dc50-4a28-9781-ef326015e386.png)


#### `dbt_artifacts` - Test
![image](https://user-images.githubusercontent.com/51203041/129607945-c13c0ecb-b641-4648-acce-63bd86ef321c.png)


#### `dbt_artifacts` - dbt deps
![image](https://user-images.githubusercontent.com/51203041/129608073-e06d27d2-1b8e-47a8-97d1-f89165b5f039.png)


