### PR TITLE
fix/updating required dbt version

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_artifacts'
 version: '0.1.0'
 config-version: 2
-require-dbt-version: ">=0.21.0"
+require-dbt-version: ">=0.20.0"
 
 models:
   dbt_artifacts:


### PR DESCRIPTION
We need to revert the current dbt version from 0.21.0 to 0.20.0 due to some errors that dbt has already fixed, but will not be pushed until the next update. This PR reverts the required dbt version from `require-dbt-version: ">=0.21.0"` to` require-dbt-version: ">=0.20.0"` 