### PR TITLE
fix/model_path update

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,6 @@
 name: 'dbt_artifacts'
 version: '0.1.0'
 config-version: 2
-profile: mack_weldon_snowflake
 require-dbt-version: "<2.0.0"
 
 models:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,6 +1,7 @@
 name: 'dbt_artifacts'
 version: '0.1.0'
 config-version: 2
+profile: mack_weldon_snowflake
 require-dbt-version: "<2.0.0"
 
 models:

--- a/models/incremental/fct_dbt_test_executions.sql
+++ b/models/incremental/fct_dbt_test_executions.sql
@@ -13,7 +13,6 @@ with tests as (
         test_name,
         test_type,
         model_schema,
-        model_path
         case
             when model_path ilike '%bespoke_tests/%'
                 then replace(model_path, 'bespoke_tests/', '')

--- a/models/incremental/fct_dbt_test_executions.sql
+++ b/models/incremental/fct_dbt_test_executions.sql
@@ -13,7 +13,16 @@ with tests as (
         test_name,
         test_type,
         model_schema,
-        replace(model_path, 'bespoke_tests/', '') as model_path
+        model_path
+        case
+            when model_path ilike '%bespoke_tests/%'
+                then replace(model_path, 'bespoke_tests/', '')
+            when model_path ilike '%schema_test/%'
+                then replace(model_path, 'schema_test/', '')
+            when model_path ilike 'data_test/%'
+                then replace(model_path, 'data_test/', '')
+            else model_path
+        end as model_path
 
     from {{ ref('int_dbt_tests') }}
 

--- a/models/incremental/fct_dbt_test_executions.sql
+++ b/models/incremental/fct_dbt_test_executions.sql
@@ -13,15 +13,7 @@ with tests as (
         test_name,
         test_type,
         model_schema,
-        case
-            when model_path ilike '%bespoke_tests/%'
-                then replace(model_path, 'bespoke_tests/', '')
-            when model_path ilike '%schema_test/%'
-                then replace(model_path, 'schema_test/', '')
-            when model_path ilike 'data_test/%'
-                then replace(model_path, 'data_test/', '')
-            else model_path
-        end as model_path
+        model_path
 
     from {{ ref('int_dbt_tests') }}
 

--- a/models/staging/stg_dbt_tests.sql
+++ b/models/staging/stg_dbt_tests.sql
@@ -26,15 +26,8 @@ flatten as (
         node.value:checksum.checksum::string as checksum,
         node.value:config.materialized::string as model_materialization,
 
-         case
-            when model_path_prep ilike '%bespoke_tests/%'
-                then replace(model_path_prep, 'bespoke_tests/', '')
-            when model_path_prep ilike '%schema_test/%'
-                then replace(model_path_prep, 'schema_test/', '')
-            when model_path_prep ilike 'data_test/%'
-                then replace(model_path_prep, 'data_test/', '')
-            else model_path_prep
-        end as model_path
+        replace(replace(replace(model_path_prep, 'bespoke_tests/', ''),
+            'schema_test/', ''), 'data_test/', '') as model_path
 
     from manifests,
     lateral flatten(input => data:nodes) as node

--- a/models/staging/stg_dbt_tests.sql
+++ b/models/staging/stg_dbt_tests.sql
@@ -24,7 +24,7 @@ flatten as (
         node.value:package_name::string as package_name,
         node.value:path::string as model_path_prep,
         node.value:checksum.checksum::string as checksum,
-        node.value:config.materialized::string as model_materialization
+        node.value:config.materialized::string as model_materialization,
 
          case
             when model_path_prep ilike '%bespoke_tests/%'

--- a/models/staging/stg_dbt_tests.sql
+++ b/models/staging/stg_dbt_tests.sql
@@ -22,9 +22,19 @@ flatten as (
         node.value:schema::string as model_schema,
         node.value:name::string as test_name,
         node.value:package_name::string as package_name,
-        node.value:path::string as model_path,
+        node.value:path::string as model_path_prep,
         node.value:checksum.checksum::string as checksum,
         node.value:config.materialized::string as model_materialization
+
+         case
+            when model_path_prep ilike '%bespoke_tests/%'
+                then replace(model_path_prep, 'bespoke_tests/', '')
+            when model_path_prep ilike '%schema_test/%'
+                then replace(model_path_prep, 'schema_test/', '')
+            when model_path_prep ilike 'data_test/%'
+                then replace(model_path_prep, 'data_test/', '')
+            else model_path_prep
+        end as model_path
 
     from manifests,
     lateral flatten(input => data:nodes) as node


### PR DESCRIPTION
## Description
This PR updates the case when statement in `fct_dbt_test_executions` to now replace both `schema_tests` and `data_tests` in the model path. Because of recent dbt updates, the `model_path` field has been causing a fan out of records in `fct_dbt_test_executions`.

## Screenshots/Testing/Validation
### Error on` Full Daily Run`
![image](https://user-images.githubusercontent.com/51203041/150432916-9a22e724-2610-440a-8f1a-e840ba025155.png)

### Example of duplicated record BEFORE fix
![image](https://user-images.githubusercontent.com/51203041/150432993-4831a2d4-4f0f-4759-ada0-b221d8b6335c.png)

### Example of previously duplicated record AFTER fix
![image](https://user-images.githubusercontent.com/51203041/150433105-11c2a1b4-8df2-45a5-aca0-cf9d8c089357.png)

### Successful dbt run
![Screen Shot 2022-01-20 at 5 40 08 PM](https://user-images.githubusercontent.com/51203041/150433540-8845e5ff-319e-467a-9f65-1e3d5c9b8d70.png)

### Successful dbt test
![Screen Shot 2022-01-20 at 5 40 42 PM](https://user-images.githubusercontent.com/51203041/150433594-f0a89f40-c285-45f9-9ee9-7231ad0bf02a.png)

## Links
[Similar PR Kate worked on last time we updated dbt](https://github.com/mackweldon/dbt_artifacts/pull/8)