### PR TITLE
update dbt_utils package to align with dbt project

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=0.8.0", "<0.9.0"]
+    version: [">=0.8.6", "<2.0.0"]


### PR DESCRIPTION
In the snowflake repo, we want to upgrade existing packages. For our dbt_utils package, it needs to have the same version between the snowflake and forked dbt_artifacts repo